### PR TITLE
Updated a few paths to show missing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Start at <https://github.com/rootzoll/raspiblitz>
 * #### [CoinKite Bunker on the RaspiBlitz](ckbunker_on_blitz.md)
 
 <p align="left">
-  <img width="400" src="/images/ckbunker.starthsm.jpg">
+  <img width="400" src="./images/ckbunker.starthsm.jpg">
 </p>
 
 * #### [Connect JoinMarket running on a Linux desktop to a remote node](joinmarket/joinmarket_desktop_to_blitz.md)
@@ -87,6 +87,6 @@ Start at <https://github.com/rootzoll/raspiblitz>
     * Bitcoin Core v0.18.1
 
 <p align="left">
-  <img width="400" src="/images/HC1.jpeg">
-  <img width="400" src="/images/XU4.jpeg">
+  <img width="400" src="./images/HC1.jpeg">
+  <img width="400" src="./images/XU4.jpeg">
 </p>

--- a/ZAPtoRaspiBolt/README.md
+++ b/ZAPtoRaspiBolt/README.md
@@ -78,7 +78,7 @@ Install instructions: https://github.com/LN-Zap/zap-desktop#install
 * Start the app and select:  
 ```Connect your own node```
 
-![](zap1.png)
+<img src="./zap1.png">
 
 
 * Fill in the next screen:  
@@ -86,7 +86,7 @@ Install instructions: https://github.com/LN-Zap/zap-desktop#install
 `~/tls.cert`  
 `~/admin.macaroon`  
 
-![](zap2.png)
+<img src="./zap1.png">
 
 * Confirm the settings on the following screen and you are done!
 

--- a/electrs/README.md
+++ b/electrs/README.md
@@ -2,7 +2,7 @@
 
 \`The server indexes the entire Bitcoin blockchain, and the resulting index enables fast queries for any given user wallet, allowing the user to keep real-time track of his balances and his transaction history using the Electrum wallet. Since it runs on the user's own machine, there is no need for the wallet to communicate with external Electrum servers, thus preserving the privacy of the user's addresses and balances.\` - [https:/github.com/romanz/electrs](https:/github.com/romanz/electrs)
 
-![electrum](./electrs/images/electrum.png)
+![electrum](./images/electrum.png)
 
 Requires 50 Gb diskpace after compactiing and ~100 GB during indexing (Nov 2019).
 
@@ -31,7 +31,7 @@ Electrs will only start serving on the port 50001 (and 50002 via Nginx) when it 
     `$ sudo systemctl status electrs`  
 
     Example output when running after indexing has finished:
-    ![electrs status](./electrs/images/electrs_status.png)
+    ![electrs status](./images/electrs_status.png)
 
 * #### Check if it is serving on the port 50001 (will appear only after indexing is complete)  
     `$ sudo -u electrs lsof -i`

--- a/electrs/README.md
+++ b/electrs/README.md
@@ -2,7 +2,7 @@
 
 \`The server indexes the entire Bitcoin blockchain, and the resulting index enables fast queries for any given user wallet, allowing the user to keep real-time track of his balances and his transaction history using the Electrum wallet. Since it runs on the user's own machine, there is no need for the wallet to communicate with external Electrum servers, thus preserving the privacy of the user's addresses and balances.\` - [https:/github.com/romanz/electrs](https:/github.com/romanz/electrs)
 
-![electrum](/electrs/images/electrum.png)
+![electrum](./electrs/images/electrum.png)
 
 Requires 50 Gb diskpace after compactiing and ~100 GB during indexing (Nov 2019).
 
@@ -31,7 +31,7 @@ Electrs will only start serving on the port 50001 (and 50002 via Nginx) when it 
     `$ sudo systemctl status electrs`  
 
     Example output when running after indexing has finished:
-    ![electrs status](/electrs/images/electrs_status.png)
+    ![electrs status](./electrs/images/electrs_status.png)
 
 * #### Check if it is serving on the port 50001 (will appear only after indexing is complete)  
     `$ sudo -u electrs lsof -i`

--- a/electrs/Tor_Hidden_Service_for_Electrs.md
+++ b/electrs/Tor_Hidden_Service_for_Electrs.md
@@ -35,7 +35,7 @@ https://electrum.readthedocs.io/en/latest/tor.html#windows
 
 Check for the blue dot when finished:
 
-![electrum behind Tor](/electrs/images/electrum_tor.png)
+![electrum behind Tor](./images/electrum_tor.png)
 
 ### [Electrum wallet on Android](https://play.google.com/store/apps/details?id=org.electrum.electrum&hl=en)
 * Open [Orbot](https://play.google.com/store/apps/details?id=org.torproject.android&hl=en)


### PR DESCRIPTION
Noticed a few images weren't (publicly) showing at:

https://openoms.github.io/bitcoin-tutorials/ckbunker_on_blitz.html
https://openoms.github.io/bitcoin-tutorials/electrs/Tor_Hidden_Service_for_Electrs.html
https://openoms.github.io/bitcoin-tutorials/electrs/
https://openoms.github.io/bitcoin-tutorials/