### PR TITLE
Change connection method from torify to torsocks

### DIFF
--- a/tor_hidden_service_example.md
+++ b/tor_hidden_service_example.md
@@ -59,7 +59,7 @@ Using SSH as an example, use any other name to be change the directory name.
 * SSH over Tor  
   in a Linux terminal use (set the custom port used for ssh):
   ```
-  torify ssh username@HiddenServiceAddress.onion:8080
+  torsocks ssh -p8080 username@HiddenServiceAddress.onion
   ```
 
 * If there is a website hosted on your .onion service use the [Tor Browser](https://www.torproject.org/) to open the address.


### PR DESCRIPTION
According to torify man page torsocks is recommended:

```
DESCRIPTION
       torify is a simple wrapper that calls torsocks with a tor-specific configuration file.

       It is provided for backward compatibility; instead you should use torsocks.
```

Also noteworthy: specifying the port after the .onion address leads to a failure 

```
requestprivacy@kubuntu:~$ torify ssh username@hostname.onion:8080

1660158579 ERROR torsocks[number]: Unable to resolve. Status reply: 1 (in socks5_recv_resolve_reply() at socks5.c:677)
ssh: Could not resolve hostname hostname.onion:8080: Non-recoverable failure in name resolution
```
Works with torify and torsocks if -p8080 flag is specified.